### PR TITLE
feat: use `builtins.fetchurl` to get a nicer download status

### DIFF
--- a/sumatrapdf.nix
+++ b/sumatrapdf.nix
@@ -22,7 +22,7 @@ in mkWindowsApp rec {
   pname = "sumatrapdf";
   version = "3.4.6";
 
-  src = fetchurl {
+  src = builtins.fetchurl {
     url = "https://www.sumatrapdfreader.org/dl/rel/${version}/SumatraPDF-${version}-64.zip";
     sha256 = "03fl6vacz5vz19ypdv5f3rdvs8msqip6yava3yy4iisbnyl5mc1b";
   };


### PR DESCRIPTION
While building a package for ableton live (the music software) using mkwindowsapp, I had the problem that no download status for the lengthy 3+ GB download of the executable was shown.  After some googling, the fix proved to be as easy as adding 9 characters. This uses `builtins.fetchurl` as an alternative to the nixpkgs `fetchurl` and integrates with the status bar perfectly.

![Screenshot from 2024-02-16 13-03-28](https://github.com/emmanuelrosa/sumatrapdf-nix/assets/67312077/e357b3a9-a7ae-4009-916f-46c9d32f8d54)

(first line is the old version, which didn't show download progress for ableton; below is the new one)